### PR TITLE
bump vsphere CPI to v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump `cloud-provider-vsphere-app` to v1.1.0.
+
 ## [0.2.0] - 2022-05-17
 
 ### Added

--- a/helm/default-apps-vsphere/values.yaml
+++ b/helm/default-apps-vsphere/values.yaml
@@ -44,7 +44,7 @@ apps:
       secret: true
     forceUpgrade: true
     namespace: kube-system
-    version: 1.0.1
+    version: 1.1.0
   clusterResources:
     appName: cluster-resources
     chartName: cluster-resources


### PR DESCRIPTION
This PR:

- bumps vsphere CPI to 1.1.0 for bugfixes.

### Checklist

- [x] Update changelog in CHANGELOG.md.
