### PR TITLE
Add observabily bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-
-- Enable renovate to update app versions.
-
 ### Added
 
 - Added `application.giantswarm.io/app-type: "bundle"` annotation
 - Added `observability-bundle` as default app
 - Supports installing apps `inCluster`
+
+### Changed
+
+- Enable renovate to update app versions.
 
 ## [0.5.0] - 2022-05-17
 

--- a/helm/default-apps-vsphere/Chart.yaml
+++ b/helm/default-apps-vsphere/Chart.yaml
@@ -8,4 +8,4 @@ name: default-apps-vsphere
 restrictions:
   compatibleProviders:
     - vsphere
-version: 0.1.0
+version: 0.6.0

--- a/helm/default-apps-vsphere/values.schema.json
+++ b/helm/default-apps-vsphere/values.schema.json
@@ -277,7 +277,7 @@
                         }
                     }
                 },
-                "observability-bundle": {
+                "observabilityBundle": {
                     "type": "object",
                     "properties": {
                         "appName": {
@@ -299,6 +299,9 @@
                                     "type": "boolean"
                                 }
                             }
+                        },
+                        "forceUpgrade": {
+                            "type": "boolean"
                         },
                         "inCluster": {
                             "type": "boolean"

--- a/helm/default-apps-vsphere/values.yaml
+++ b/helm/default-apps-vsphere/values.yaml
@@ -111,15 +111,16 @@ apps:
     # used by renovate
     # repo: giantswarm/node-exporter-app
     version: 1.13.0
-  observability-bundle:
+  observabilityBundle:
     appName: observability-bundle
     chartName: observability-bundle
     catalog: default
-    namespace: ""
-    inCluster: true
     clusterValues:
       configMap: true
       secret: false
+    forceUpgrade: false
+    inCluster: true
+    namespace: kube-system
     # used by renovate
     # repo: giantswarm/observability-bundle
-    version: 0.1.3
+    version: 0.1.4


### PR DESCRIPTION
This PR:

- updates the observability bundle

I did not change the changelog because I added a previous version of the prometheus agent and the change was not released
