### PR TITLE
Add cert-manager app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- ⚠️ Breaking: Remove the deprecated `cluster-resources` app
+- ⚠️ Breaking: Remove the deprecated `cluster-resources` app.
+- Add `cert-manager`.
 
 ## [0.8.0] - 2023-03-20
 

--- a/helm/default-apps-vsphere/values.yaml
+++ b/helm/default-apps-vsphere/values.yaml
@@ -27,6 +27,18 @@ apps:
     # used by renovate
     # repo: giantswarm/cert-exporter
     version: 2.3.1
+  certManager:
+    appName: cert-manager
+    chartName: cert-manager-app
+    catalog: default
+    clusterValues:
+      configMap: true
+      secret: true
+    forceUpgrade: true
+    namespace: kube-system
+    # used by renovate
+    # repo: giantswarm/cert-manager-app
+    version: 2.20.3
   kubeStateMetrics:
     appName: kube-state-metrics
     chartName: kube-state-metrics


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2189

As we decided in the last Kaas Sync, to have `cert-manager` in default-apps is standard. 

Verified in a WC of `gerkan`.

### Testing

- [x] fresh install works
- [x] upgrade from previous version works

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
