### PR TITLE
Bump Observability Bundle to 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `cert-manager-app` to `2.21.0`.
 - Bump `metrics-server-app` to `2.1.0`.
 - Bump `net-exporter` to `1.14.0`.
+- Bump `observability-bundle` to `0.4.0`.
 - Enable configuration of Apps with the [extraConfig](https://github.com/giantswarm/rfc/tree/main/multi-layer-app-config#enhancing-app-cr) key.
+
+### Removed
+
+- Remove kube-state-metrics app as it is now included in the observability-bundle.
 
 ## [0.8.0] - 2023-03-20
 

--- a/helm/default-apps-vsphere/values.schema.json
+++ b/helm/default-apps-vsphere/values.schema.json
@@ -86,40 +86,6 @@
                         }
                     }
                 },
-                "kubeStateMetrics": {
-                    "type": "object",
-                    "properties": {
-                        "appName": {
-                            "type": "string"
-                        },
-                        "catalog": {
-                            "type": "string"
-                        },
-                        "chartName": {
-                            "type": "string"
-                        },
-                        "clusterValues": {
-                            "type": "object",
-                            "properties": {
-                                "configMap": {
-                                    "type": "boolean"
-                                },
-                                "secret": {
-                                    "type": "boolean"
-                                }
-                            }
-                        },
-                        "forceUpgrade": {
-                            "type": "boolean"
-                        },
-                        "namespace": {
-                            "type": "string"
-                        },
-                        "version": {
-                            "type": "string"
-                        }
-                    }
-                },
                 "metricsServer": {
                     "type": "object",
                     "properties": {

--- a/helm/default-apps-vsphere/values.yaml
+++ b/helm/default-apps-vsphere/values.yaml
@@ -39,18 +39,6 @@ apps:
     # used by renovate
     # repo: giantswarm/cert-manager-app
     version: 2.21.0
-  kubeStateMetrics:
-    appName: kube-state-metrics
-    chartName: kube-state-metrics
-    catalog: default
-    clusterValues:
-      configMap: true
-      secret: false
-    forceUpgrade: true
-    namespace: kube-system
-    # used by renovate
-    # repo: giantswarm/kube-state-metrics-app
-    version: 1.15.0
   metricsServer:
     appName: metrics-server
     chartName: metrics-server-app
@@ -99,7 +87,7 @@ apps:
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/observability-bundle
-    version: 0.3.0
+    version: 0.4.0
   vpa:
     appName: vertical-pod-autoscaler
     chartName: vertical-pod-autoscaler-app


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/26221

### What this PR does / why we need it
This PR bumps the observability bundle and remove kube-state-metrics as it is now included

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
