### PR TITLE
Bump observability-bundle to 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump `observability-bundle` to `0.4.1`.
+
 ## [0.9.0] - 2023-04-13
 
 ### Changed

--- a/helm/default-apps-vsphere/values.yaml
+++ b/helm/default-apps-vsphere/values.yaml
@@ -87,7 +87,7 @@ apps:
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/observability-bundle
-    version: 0.4.0
+    version: 0.4.1
   vpa:
     appName: vertical-pod-autoscaler
     chartName: vertical-pod-autoscaler-app


### PR DESCRIPTION
This PR:

towards https://github.com/giantswarm/giantswarm/issues/26629

A new version of prometheus-agent has been released to fix the watchdog and the data lost.
We have to update the observability-bundle with this version.

### Testing

Description on how {APP-NAME} can be tested.

- [ ] fresh install works
- [ ] upgrade from previous version works

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
