### PR TITLE
Bump observability-bundle to 0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Bump `observability-bundle` to `0.4.1`.
+- Bump `observability-bundle` to `0.4.2`.
 
 ## [0.9.0] - 2023-04-13
 

--- a/helm/default-apps-vsphere/values.yaml
+++ b/helm/default-apps-vsphere/values.yaml
@@ -87,7 +87,7 @@ apps:
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/observability-bundle
-    version: 0.4.1
+    version: 0.4.2
   vpa:
     appName: vertical-pod-autoscaler
     chartName: vertical-pod-autoscaler-app


### PR DESCRIPTION
This PR:

towards https://github.com/giantswarm/giantswarm/issues/26674

Bump observability-bundle to 0.4.2: fix preStop with removing the wal directory in the prometheus-agent

### Testing

Description on how {APP-NAME} can be tested.

- [ ] fresh install works
- [ ] upgrade from previous version works

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
