### PR TITLE
Set ciliumNetworkPolicy.enabled=true in supporting apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Set `ciliumNetworkPolicy.enabled=true` for `cert-manager-app`.
 - Bump `observability-bundle` to `0.4.2`.
 
 ## [0.9.0] - 2023-04-13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump `observability-bundle` to `0.4.1`.
+
 ## [0.9.0] - 2023-04-13
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Bump `observability-bundle` to `0.4.1`.
+- Bump `observability-bundle` to `0.4.2`.
 
 ## [0.9.0] - 2023-04-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Set `ciliumNetworkPolicy.enabled=true` for `cert-manager-app`.
+- Add support for deploying on clusters where network traffic is completely blocked by default with cilium.
 - Bump `observability-bundle` to `0.4.2`.
 
 ## [0.9.0] - 2023-04-13

--- a/helm/default-apps-vsphere/values.schema.json
+++ b/helm/default-apps-vsphere/values.schema.json
@@ -67,7 +67,6 @@
             }
         }
     },
-    "additionalProperties": false,
     "type": "object",
     "properties": {
         "apps": {

--- a/helm/default-apps-vsphere/values.schema.json
+++ b/helm/default-apps-vsphere/values.schema.json
@@ -106,13 +106,13 @@
             "type": "object",
             "properties": {
                 "certExporter": {
-                    "$ref": "#/definitions/userConfig"
+                    "$ref": "#/$defa/userConfig"
                 },
                 "certManager": {
-                    "$ref": "#/definitions/userConfig"
+                    "$ref": "#/$defa/userConfig"
                 },
                 "metricsServer": {
-                    "$ref": "#/definitions/userConfig"
+                    "$ref": "#/$defa/userConfig"
                 },
                 "netExporter": {
                     "$ref": "#/$defs/userConfig"

--- a/helm/default-apps-vsphere/values.schema.json
+++ b/helm/default-apps-vsphere/values.schema.json
@@ -122,7 +122,7 @@
                 },
                 "vpa": {
                     "$ref": "#/definitions/userConfig"
-                ,
+                }
             }
         }
     }

--- a/helm/default-apps-vsphere/values.schema.json
+++ b/helm/default-apps-vsphere/values.schema.json
@@ -105,10 +105,13 @@
         "userConfig": {
             "type": "object",
             "properties": {
+                "certExporter": {
+                    "$ref": "#/definitions/userConfig"
+                },
                 "certManager": {
                     "$ref": "#/definitions/userConfig"
                 },
-                "certExporter": {
+                "metricsServer": {
                     "$ref": "#/definitions/userConfig"
                 },
                 "netExporter": {
@@ -116,7 +119,10 @@
                 },
                 "nodeExporter": {
                     "$ref": "#/definitions/userConfig"
-                }
+                },
+                "vpa": {
+                    "$ref": "#/definitions/userConfig"
+                ,
             }
         }
     }

--- a/helm/default-apps-vsphere/values.schema.json
+++ b/helm/default-apps-vsphere/values.schema.json
@@ -1,5 +1,20 @@
 {
     "$schema": "http://json-schema.org/schema#",
+    "definitions": {
+        "userConfig": {
+            "type": "object",
+            "properties": {
+                "configMap": {
+                    "type": "object",
+                    "properties": {
+                        "values": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        }
+    },
     "type": "object",
     "properties": {
         "apps": {
@@ -240,43 +255,16 @@
             "type": "object",
             "properties": {
                 "certManager": {
-                    "type": "object",
-                    "properties": {
-                        "configMap": {
-                            "type": "object",
-                            "properties": {
-                                "values": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
+                    "$ref": "#/definitions/userConfig"
+                },
+                "certExporter": {
+                    "$ref": "#/definitions/userConfig"
                 },
                 "netExporter": {
-                    "type": "object",
-                    "properties": {
-                        "configMap": {
-                            "type": "object",
-                            "properties": {
-                                "values": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
+                    "$ref": "#/definitions/userConfig"
                 },
                 "nodeExporter": {
-                    "type": "object",
-                    "properties": {
-                        "configMap": {
-                            "type": "object",
-                            "properties": {
-                                "values": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
+                    "$ref": "#/definitions/userConfig"
                 }
             }
         }

--- a/helm/default-apps-vsphere/values.schema.json
+++ b/helm/default-apps-vsphere/values.schema.json
@@ -106,13 +106,13 @@
             "type": "object",
             "properties": {
                 "certExporter": {
-                    "$ref": "#/$defa/userConfig"
+                    "$ref": "#/$defs/userConfig"
                 },
                 "certManager": {
-                    "$ref": "#/$defa/userConfig"
+                    "$ref": "#/$defs/userConfig"
                 },
                 "metricsServer": {
-                    "$ref": "#/$defa/userConfig"
+                    "$ref": "#/$defs/userConfig"
                 },
                 "netExporter": {
                     "$ref": "#/$defs/userConfig"

--- a/helm/default-apps-vsphere/values.schema.json
+++ b/helm/default-apps-vsphere/values.schema.json
@@ -239,6 +239,19 @@
         "userConfig": {
             "type": "object",
             "properties": {
+                "certManager": {
+                    "type": "object",
+                    "properties": {
+                        "configMap": {
+                            "type": "object",
+                            "properties": {
+                                "values": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
                 "netExporter": {
                     "type": "object",
                     "properties": {

--- a/helm/default-apps-vsphere/values.yaml
+++ b/helm/default-apps-vsphere/values.yaml
@@ -87,7 +87,7 @@ apps:
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/observability-bundle
-    version: 0.4.0
+    version: 0.4.1
   vpa:
     appName: vertical-pod-autoscaler
     chartName: vertical-pod-autoscaler-app

--- a/helm/default-apps-vsphere/values.yaml
+++ b/helm/default-apps-vsphere/values.yaml
@@ -87,7 +87,7 @@ apps:
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/observability-bundle
-    version: 0.4.2
+    version: 0.4.3
   vpa:
     appName: vertical-pod-autoscaler
     chartName: vertical-pod-autoscaler-app

--- a/helm/default-apps-vsphere/values.yaml
+++ b/helm/default-apps-vsphere/values.yaml
@@ -3,6 +3,10 @@ organization: ""
 managementCluster: ""
 
 userConfig:
+  certManager:
+    values: |
+      ciliumNetworkPolicy:
+        enabled: true
   netExporter:
     configMap:
       values: |

--- a/helm/default-apps-vsphere/values.yaml
+++ b/helm/default-apps-vsphere/values.yaml
@@ -7,6 +7,10 @@ userConfig:
     values: |
       ciliumNetworkPolicy:
         enabled: true
+  certExporter:
+    values: |
+      ciliumNetworkPolicy:
+        enabled: true
   netExporter:
     configMap:
       values: |

--- a/helm/default-apps-vsphere/values.yaml
+++ b/helm/default-apps-vsphere/values.yaml
@@ -3,17 +3,26 @@ organization: ""
 managementCluster: ""
 
 userConfig:
-  certManager:
-    values: |
-      ciliumNetworkPolicy:
-        enabled: true
   certExporter:
-    values: |
-      ciliumNetworkPolicy:
-        enabled: true
+    configMap:
+      values: |
+        ciliumNetworkPolicy:
+          enabled: true
+  certManager:
+    configMap:
+      values: |
+        ciliumNetworkPolicy:
+          enabled: true
+  metricsServer:
+    configMap:
+      values: |
+        ciliumNetworkPolicy:
+          enabled: true
   netExporter:
     configMap:
       values: |
+        ciliumNetworkPolicy:
+          enabled: true
         dns:
           service: kube-dns
   nodeExporter:
@@ -21,6 +30,11 @@ userConfig:
       values: |
         disableConntrackCollector: true
         disableNvmeCollector: true
+  vpa:
+    configMap:
+      values: |
+        ciliumNetworkPolicy:
+          enabled: true
 
 apps:
   certExporter:

--- a/helm/default-apps-vsphere/values.yaml
+++ b/helm/default-apps-vsphere/values.yaml
@@ -62,7 +62,7 @@ apps:
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/net-exporter
-    version: 1.14.0
+    version: 1.14.1
   nodeExporter:
     appName: node-exporter
     chartName: node-exporter-app

--- a/helm/default-apps-vsphere/values.yaml
+++ b/helm/default-apps-vsphere/values.yaml
@@ -87,7 +87,7 @@ apps:
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/observability-bundle
-    version: 0.4.1
+    version: 0.4.2
   vpa:
     appName: vertical-pod-autoscaler
     chartName: vertical-pod-autoscaler-app


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/23014
Towards https://github.com/giantswarm/roadmap/issues/1949

This is so `default-apps-vsphere` can be deployed in a locked down cluster without current default cilium policies.