### PR TITLE
Fix cluster DNS service name for net-exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `observability-bundle` to `0.4.2`.
 
+### Fixed
+
+- Fix cluster DNS service name for `net-exporter` (`kube-dns` -> `coredns`).
+
 ## [0.9.0] - 2023-04-13
 
 ### Changed

--- a/helm/default-apps-vsphere/values.schema.json
+++ b/helm/default-apps-vsphere/values.schema.json
@@ -82,9 +82,6 @@
                 "metricsServer": {
                     "$ref": "#/$defs/app"
                 },
-                "netExporter": {
-                    "$ref": "#/$defs/app"
-                },
                 "nodeExporter": {
                     "$ref": "#/$defs/app"
                 },

--- a/helm/default-apps-vsphere/values.yaml
+++ b/helm/default-apps-vsphere/values.yaml
@@ -3,11 +3,6 @@ organization: ""
 managementCluster: ""
 
 userConfig:
-  netExporter:
-    configMap:
-      values: |
-        dns:
-          service: kube-dns
   nodeExporter:
     configMap:
       values: |


### PR DESCRIPTION
Incident: https://gigantic.slack.com/archives/C058U5RSAPM

We are deploying `coredns` with `coredns-app` now so the service name is taken from the app instead of kubeadm default.