### PR TITLE
 correct net-exporter dns service name to use coredns-app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `etcd-kubernetes-resources-count-exporter`.
 
+### Changed
+
+- Remove override of dns Service name (not required for coredns-app).
+
 ## [0.9.2] - 2023-05-22
 
 ### Changed

--- a/helm/default-apps-vsphere/values.yaml
+++ b/helm/default-apps-vsphere/values.yaml
@@ -34,8 +34,6 @@ userConfig:
       values: |
         ciliumNetworkPolicy:
           enabled: true
-        dns:
-          service: kube-dns
   nodeExporter:
     configMap:
       values: |


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/27710

This PR:

- removes the override of the DNS Service name as this is not required when using giantswarm/coredns-app

### Checklist

- [x] Update changelog in CHANGELOG.md.
