### PR TITLE
Fix cert-manager parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Update `cert-manager` parameters for v3.
+
 ## [0.10.1] - 2023-08-03
 
 ### Changed

--- a/helm/default-apps-vsphere/values.yaml
+++ b/helm/default-apps-vsphere/values.yaml
@@ -13,10 +13,6 @@ userConfig:
       values: |
         ciliumNetworkPolicy:
           enabled: true
-        # cert-manager-app v2.x.x
-        controller:
-          defaultIssuer:
-            name: letsencrypt-giantswarm
         # cert-manager-app v3.x.x
         ingressShim:
           defaultIssuerName: letsencrypt-giantswarm

--- a/helm/default-apps-vsphere/values.yaml
+++ b/helm/default-apps-vsphere/values.yaml
@@ -13,7 +13,6 @@ userConfig:
       values: |
         ciliumNetworkPolicy:
           enabled: true
-        # cert-manager-app v3.x.x
         ingressShim:
           defaultIssuerName: letsencrypt-giantswarm
           defaultIssuerKind: ClusterIssuer

--- a/helm/default-apps-vsphere/values.yaml
+++ b/helm/default-apps-vsphere/values.yaml
@@ -13,6 +13,16 @@ userConfig:
       values: |
         ciliumNetworkPolicy:
           enabled: true
+        # cert-manager-app v2.x.x
+        controller:
+          defaultIssuer:
+            name: letsencrypt-giantswarm
+        # cert-manager-app v3.x.x
+        ingressShim:
+          defaultIssuerName: letsencrypt-giantswarm
+          defaultIssuerKind: ClusterIssuer
+          defaultIssuerGroup: cert-manager.io
+        enableServiceLinks: true
   etcdKubernetesResourceCountExporter:
     configMap:
       values: |


### PR DESCRIPTION
Mimicked what we have for cloud-director https://github.com/giantswarm/default-apps-cloud-director/blob/main/helm/default-apps-cloud-director/values.yaml#L14C1-L25C33

### Testing

- [x] fresh install works
- [x] upgrade from previous version works

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
