### PR TITLE
Add dependency for vertical-pod-autoscaler apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add dependency between `vertical-pod-autoscaler-crd` and `vertical-pod-autoscaler`.
+
 ## [0.11.1] - 2023-09-21
 
 ### Added

--- a/helm/default-apps-vsphere/templates/apps.yaml
+++ b/helm/default-apps-vsphere/templates/apps.yaml
@@ -6,6 +6,10 @@ kind: App
 metadata:
   annotations:
     chart-operator.giantswarm.io/force-helm-upgrade: "{{ .forceUpgrade }}"
+    {{- if .dependsOn }}
+    # app-operator will make sure that the app on which it depends is installed before
+    app-operator.giantswarm.io/depends-on: {{ printf "%s-%s" $.Values.clusterName .dependsOn -}}
+    {{- end }}
   labels:
     {{- include "labels.common" $ | nindent 4 }}
     {{- if .inCluster }}  

--- a/helm/default-apps-vsphere/values.schema.json
+++ b/helm/default-apps-vsphere/values.schema.json
@@ -25,6 +25,9 @@
                         }
                     }
                 },
+                "dependsOn": {
+                    "type": "string"
+                },
                 "extraConfigs": {
                     "type": "array",
                     "items": {

--- a/helm/default-apps-vsphere/values.yaml
+++ b/helm/default-apps-vsphere/values.yaml
@@ -146,6 +146,7 @@ apps:
     clusterValues:
       configMap: true
       secret: false
+    dependsOn: vertical-pod-autoscaler-crd
     forceUpgrade: false
     namespace: kube-system
     # used by renovate


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/28472

When `vertical-pod-autoscaler` is installed before `vertical-pod-autoscaler-crd`, tests fail. [See](https://gigantic.slack.com/archives/C01F7T2MNRL/p1697036726846669) 

### Testing

- [ ] fresh install works
- [ ] upgrade from previous version works

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
