### PR TITLE
Revert "Enable ciliumnetworkpolicies for kube-state-metrics"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added `chart-operator-extension` version `v1.1.1` that contains e.g. `ServiceMonitors` for `chart-operator`.
 - Add dependency between `vertical-pod-autoscaler-crd` and `vertical-pod-autoscaler`.
-- Enable `ciliumNetworkPolicy` for `observabilityBundle`.
-
-### Removed
-
-- `unconfined` apparmor profile for `nodeExporter` app.
 
 ### Changed
 

--- a/helm/default-apps-vsphere/values.yaml
+++ b/helm/default-apps-vsphere/values.yaml
@@ -44,11 +44,9 @@ userConfig:
       values: |
         disableConntrackCollector: true
         disableNvmeCollector: true
-  observabilityBundle:
-    configMap:
-      values: |
-        ciliumNetworkPolicy:
-          enabled: true
+        # remove the pod annotation once we use flatcar images
+        podAnnotations:
+          container.apparmor.security.beta.kubernetes.io/node-exporter: "unconfined"
   vpa:
     configMap:
       values: |


### PR DESCRIPTION
Although, it works well with the old ubuntu image in locked-in scenario (`.Values.connectivity.network.allowAllEgress == false`), the new flatcar image (`prometheus-prometheus-agent-0`) has some troubles with it:

```
ts=2023-11-09T11:57:24.555Z caller=dedupe.go:112 component=remote level=warn remote_name=prometheus-meta-operator url=https://prometheus.gcapeverde.test.gigantic.io/flatcar10/api/v1/write msg="Failed to send batch, retrying" err="Post \"https://prometheus.gcapeverde.test.gigantic.io/flatcar10/api/v1/write\": dial tcp: lookup prometheus.gcapeverde.test.gigantic.io on 172.31.0.10:53: read udp 10.244.2.93:54953->172.31.0.10:53: i/o timeout"
```


Reverts giantswarm/default-apps-vsphere#162