### PR TITLE
Enable ciliumnetworkpolicies for kube-state-metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added `chart-operator-extension` version `v1.1.1` that contains e.g. `ServiceMonitors` for `chart-operator`.
 - Add dependency between `vertical-pod-autoscaler-crd` and `vertical-pod-autoscaler`.
+- Enable `ciliumNetworkPolicy` for `observabilityBundle`.
+
+### Removed
+
+- `unconfined` apparmor profile for `nodeExporter` app.
 
 ### Changed
 

--- a/helm/default-apps-vsphere/values.yaml
+++ b/helm/default-apps-vsphere/values.yaml
@@ -44,9 +44,11 @@ userConfig:
       values: |
         disableConntrackCollector: true
         disableNvmeCollector: true
-        # remove the pod annotation once we use flatcar images
-        podAnnotations:
-          container.apparmor.security.beta.kubernetes.io/node-exporter: "unconfined"
+  observabilityBundle:
+    configMap:
+      values: |
+        ciliumNetworkPolicy:
+          enabled: true
   vpa:
     configMap:
       values: |


### PR DESCRIPTION
& removing unconfined apparmor profile since we switched to flatcar

the missing ciliumnetpol is causing this:

```
prometheus-operator-app-kube-state-metrics-947999bf6-bwkbb
W1107 13:24:36.914329       1 reflector.go:533] pkg/mod/k8s.io/client-go@v0.27.5/tools/cache/reflector.go:231: failed to list *v1.Pod: Get "https://172.31.0.1:443/api/v1/pods?resourceVersion=2533153": dial tcp 172.31.0.1:443: i/o timeout
```

when we install the deny all netpols in `kube-system`.


Note: I reverted the previous one in order to debug the flatcar networking issue, now it can be reopen again.