### PR TITLE
fix-psp-values-for-observability-bundle

### DIFF
--- a/helm/default-apps-vsphere/values.yaml
+++ b/helm/default-apps-vsphere/values.yaml
@@ -47,8 +47,35 @@ userConfig:
   observabilityBundle:
     configMap:
       values: |
-        ciliumNetworkPolicy:
-          enabled: true
+        userConfig:
+          kubePrometheusStack:
+            configMap:
+              values:
+                global:
+                  rbac:
+                    pspEnabled: true
+                kube-prometheus-stack:
+                  grafana:
+                    rbac:
+                      pspEnabled: true
+                  kube-state-metrics:
+                    podSecurityPolicy:
+                      enabled: true
+                  prometheus-node-exporter:
+                    rbac:
+                      pspEnabled: true
+          prometheusAgent:
+            configMap:
+              values:
+                prometheus-agent:
+                  psp:
+                    enabled: true
+          promtail:
+            configMap:
+              values:
+                promtail:
+                  rbac:
+                    pspEnabled: true
   vpa:
     configMap:
       values: |


### PR DESCRIPTION
### What this PR does / why we need it

Towards giantswarm/giantswarm#29529

This PR is the same as https://github.com/giantswarm/default-apps-azure/pull/203 and https://github.com/giantswarm/default-apps-aws/pull/388

This PR:

- adds/changes/removes etc

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.

### Testing

Description on how default-apps-vsphere can be tested.

- [ ] fresh install works
- [ ] upgrade from previous version works

### Trigger e2e tests

<!--
We currently have one pipeline that tests both cluster creation and cluster upgrades. You can trigger this pipeline by writing this commands in a pull request comment or description
- `/run cluster-test-suites`

If for some reason you want to skip the e2e tests, remove the following line.
-->

/run cluster-test-suites
