### PR TITLE
Avoid templating namespace for extraConfigmap

### DIFF
--- a/helm/default-apps-vsphere/templates/apps.yaml
+++ b/helm/default-apps-vsphere/templates/apps.yaml
@@ -55,7 +55,7 @@ spec:
   {{- range $extraConfig := .extraConfigs }}
   - kind: {{ $extraConfig.kind }}
     name: {{ tpl $extraConfig.name $ }}
-    namespace: {{ tpl $extraConfig.namespace $ }}
+    namespace: {{ $.Release.Namespace }}
   {{- end }}
   {{- end }}
 {{- with (get $.Values.userConfig $key) }}

--- a/helm/default-apps-vsphere/values.yaml
+++ b/helm/default-apps-vsphere/values.yaml
@@ -197,4 +197,3 @@ apps:
     extraConfigs:
       - kind: configMap
         name: "{{ $.Values.clusterName }}-teleport-kube-agent-config"
-        namespace: "{{ $.Release.Namespace }}"


### PR DESCRIPTION
Encounter this during upgrade of bamboo to default-apps v0.12.0

```
   Reason:         template: default-apps-vsphere/templates/apps.yaml:58:34: executing "default-apps-vsphere/templates/apps.yaml" at <$extraConfig.namespace>: wrong type for value; expected string; got interface {}
    Status:         unknown-error
  Version:          0.11.0
Events:
  Type    Reason      Age                    From                      Message
  ----    ------      ----                   ----                      -------
  Normal  AppUpdated  2m48s (x2 over 2m48s)  app-admission-controller  version has been changed to `0.12.0`
```


This PR:

- adds/changes/removes etc

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.

### Testing

Description on how default-apps-vsphere can be tested.

- [ ] fresh install works
- [ ] upgrade from previous version works

### Trigger e2e tests

<!--
We currently have one pipeline that tests both cluster creation and cluster upgrades. You can trigger this pipeline by writing this commands in a pull request comment or description
- `/run cluster-test-suites`

If for some reason you want to skip the e2e tests, remove the following line.
-->

/run cluster-test-suites
