### PR TITLE
Bump observability bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Bump `observability-bundle` to `1.2.1`.
 - Use a YAML object for the apps configuration, so that defaults are not overwritten when users pass custom values.
 
 ## [0.12.0] - 2023-12-04

--- a/helm/default-apps-vsphere/values.yaml
+++ b/helm/default-apps-vsphere/values.yaml
@@ -44,38 +44,6 @@ userConfig:
       values:
         disableConntrackCollector: true
         disableNvmeCollector: true
-  observabilityBundle:
-    configMap:
-      values:
-        userConfig:
-          kubePrometheusStack:
-            configMap:
-              values:
-                global:
-                  rbac:
-                    pspEnabled: true
-                kube-prometheus-stack:
-                  grafana:
-                    rbac:
-                      pspEnabled: true
-                  kube-state-metrics:
-                    podSecurityPolicy:
-                      enabled: true
-                  prometheus-node-exporter:
-                    rbac:
-                      pspEnabled: true
-          prometheusAgent:
-            configMap:
-              values:
-                prometheus-agent:
-                  psp:
-                    enabled: true
-          promtail:
-            configMap:
-              values:
-                promtail:
-                  rbac:
-                    pspEnabled: true
   vpa:
     configMap:
       values:
@@ -180,7 +148,7 @@ apps:
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/observability-bundle
-    version: 1.1.1
+    version: 1.2.1
   vpa:
     appName: vertical-pod-autoscaler
     chartName: vertical-pod-autoscaler-app


### PR DESCRIPTION
This PR:

- upgrades the olly bundle and adds back the pss toggle for the bundled apps

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.

### Testing

Description on how default-apps-vsphere can be tested.

- [ ] fresh install works
- [ ] upgrade from previous version works

### Trigger e2e tests

<!--
We currently have one pipeline that tests both cluster creation and cluster upgrades. You can trigger this pipeline by writing this commands in a pull request comment or description
- `/run cluster-test-suites`

If for some reason you want to skip the e2e tests, remove the following line.
-->

/run cluster-test-suites
