### PR TITLE
Generate schema docs in the project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Include support for schemadocs to generate Chart README file
+
 ### Changed
 
 - Bump `observability-bundle` to `1.2.1`.

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@
 
 include Makefile.*.mk
 
+VALUES_SCHEMA=$(shell find ./helm -maxdepth 2 -name values.schema.json)
+CHART_README=$(shell find ./helm -maxdepth 2 -name README.md)
+
 ##@ General
 
 # The help target prints out all targets with their descriptions organized
@@ -17,6 +20,11 @@ include Makefile.*.mk
 # https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_parameters
 # More info on the awk command:
 # http://linuxcommand.org/lc3_adv_awk.php
+
+.PHONY: generate-docs
+generate-docs: ## Generate values documentation from schema
+	go install github.com/giantswarm/schemadocs@latest
+	schemadocs generate $(VALUES_SCHEMA) -o $(CHART_README)
 
 .PHONY: help
 help: ## Display this help.

--- a/helm/default-apps-vsphere/README.md
+++ b/helm/default-apps-vsphere/README.md
@@ -1,0 +1,159 @@
+# Values schema documentation
+
+This page lists all available configuration options, based on the [configuration values schema](values.schema.json).
+
+<!-- DOCS_START -->
+
+### Apps
+
+Properties within the `.apps` top-level object
+
+| **Property** | **Description** | **More Details** |
+| :----------- | :-------------- | :--------------- |
+| `apps.certExporter` |**None**|**Type:** `object`<br/>|
+| `apps.certExporter.appName` |**None**|**Type:** `string`<br/>|
+| `apps.certExporter.catalog` |**None**|**Type:** `string`<br/>|
+| `apps.certExporter.chartName` |**None**|**Type:** `string`<br/>|
+| `apps.certExporter.clusterValues` |**None**|**Type:** `object`<br/>|
+| `apps.certExporter.clusterValues.configMap` |**None**|**Type:** `boolean`<br/>|
+| `apps.certExporter.clusterValues.secret` |**None**|**Type:** `boolean`<br/>|
+| `apps.certExporter.dependsOn` |**None**|**Type:** `string`<br/>|
+| `apps.certExporter.extraConfigs` |**None**|**Type:** `array`<br/>|
+| `apps.certExporter.extraConfigs[*]` |**None**||
+| `apps.certExporter.extraConfigs[*].kind` |**None**|**Type:** `string`<br/>|
+| `apps.certExporter.extraConfigs[*].name` |**None**|**Type:** `string`<br/>|
+| `apps.certExporter.forceUpgrade` |**None**|**Type:** `boolean`<br/>|
+| `apps.certExporter.inCluster` |**None**|**Type:** `boolean`<br/>|
+| `apps.certExporter.namespace` |**None**|**Type:** `string`<br/>|
+| `apps.certExporter.version` |**None**|**Type:** `string`<br/>|
+| `apps.chartOperatorExtensions` |**None**|**Type:** `object`<br/>|
+| `apps.chartOperatorExtensions.appName` |**None**|**Type:** `string`<br/>|
+| `apps.chartOperatorExtensions.catalog` |**None**|**Type:** `string`<br/>|
+| `apps.chartOperatorExtensions.chartName` |**None**|**Type:** `string`<br/>|
+| `apps.chartOperatorExtensions.clusterValues` |**None**|**Type:** `object`<br/>|
+| `apps.chartOperatorExtensions.clusterValues.configMap` |**None**|**Type:** `boolean`<br/>|
+| `apps.chartOperatorExtensions.clusterValues.secret` |**None**|**Type:** `boolean`<br/>|
+| `apps.chartOperatorExtensions.dependsOn` |**None**|**Type:** `string`<br/>|
+| `apps.chartOperatorExtensions.extraConfigs` |**None**|**Type:** `array`<br/>|
+| `apps.chartOperatorExtensions.extraConfigs[*]` |**None**||
+| `apps.chartOperatorExtensions.extraConfigs[*].kind` |**None**|**Type:** `string`<br/>|
+| `apps.chartOperatorExtensions.extraConfigs[*].name` |**None**|**Type:** `string`<br/>|
+| `apps.chartOperatorExtensions.forceUpgrade` |**None**|**Type:** `boolean`<br/>|
+| `apps.chartOperatorExtensions.inCluster` |**None**|**Type:** `boolean`<br/>|
+| `apps.chartOperatorExtensions.namespace` |**None**|**Type:** `string`<br/>|
+| `apps.chartOperatorExtensions.version` |**None**|**Type:** `string`<br/>|
+| `apps.clusterResources` |**None**|**Type:** `object`<br/>|
+| `apps.clusterResources.appName` |**None**|**Type:** `string`<br/>|
+| `apps.clusterResources.catalog` |**None**|**Type:** `string`<br/>|
+| `apps.clusterResources.chartName` |**None**|**Type:** `string`<br/>|
+| `apps.clusterResources.clusterValues` |**None**|**Type:** `object`<br/>|
+| `apps.clusterResources.clusterValues.configMap` |**None**|**Type:** `boolean`<br/>|
+| `apps.clusterResources.clusterValues.secret` |**None**|**Type:** `boolean`<br/>|
+| `apps.clusterResources.dependsOn` |**None**|**Type:** `string`<br/>|
+| `apps.clusterResources.extraConfigs` |**None**|**Type:** `array`<br/>|
+| `apps.clusterResources.extraConfigs[*]` |**None**||
+| `apps.clusterResources.extraConfigs[*].kind` |**None**|**Type:** `string`<br/>|
+| `apps.clusterResources.extraConfigs[*].name` |**None**|**Type:** `string`<br/>|
+| `apps.clusterResources.forceUpgrade` |**None**|**Type:** `boolean`<br/>|
+| `apps.clusterResources.inCluster` |**None**|**Type:** `boolean`<br/>|
+| `apps.clusterResources.namespace` |**None**|**Type:** `string`<br/>|
+| `apps.clusterResources.version` |**None**|**Type:** `string`<br/>|
+| `apps.metricsServer` |**None**|**Type:** `object`<br/>|
+| `apps.metricsServer.appName` |**None**|**Type:** `string`<br/>|
+| `apps.metricsServer.catalog` |**None**|**Type:** `string`<br/>|
+| `apps.metricsServer.chartName` |**None**|**Type:** `string`<br/>|
+| `apps.metricsServer.clusterValues` |**None**|**Type:** `object`<br/>|
+| `apps.metricsServer.clusterValues.configMap` |**None**|**Type:** `boolean`<br/>|
+| `apps.metricsServer.clusterValues.secret` |**None**|**Type:** `boolean`<br/>|
+| `apps.metricsServer.dependsOn` |**None**|**Type:** `string`<br/>|
+| `apps.metricsServer.extraConfigs` |**None**|**Type:** `array`<br/>|
+| `apps.metricsServer.extraConfigs[*]` |**None**||
+| `apps.metricsServer.extraConfigs[*].kind` |**None**|**Type:** `string`<br/>|
+| `apps.metricsServer.extraConfigs[*].name` |**None**|**Type:** `string`<br/>|
+| `apps.metricsServer.forceUpgrade` |**None**|**Type:** `boolean`<br/>|
+| `apps.metricsServer.inCluster` |**None**|**Type:** `boolean`<br/>|
+| `apps.metricsServer.namespace` |**None**|**Type:** `string`<br/>|
+| `apps.metricsServer.version` |**None**|**Type:** `string`<br/>|
+| `apps.nodeExporter` |**None**|**Type:** `object`<br/>|
+| `apps.nodeExporter.appName` |**None**|**Type:** `string`<br/>|
+| `apps.nodeExporter.catalog` |**None**|**Type:** `string`<br/>|
+| `apps.nodeExporter.chartName` |**None**|**Type:** `string`<br/>|
+| `apps.nodeExporter.clusterValues` |**None**|**Type:** `object`<br/>|
+| `apps.nodeExporter.clusterValues.configMap` |**None**|**Type:** `boolean`<br/>|
+| `apps.nodeExporter.clusterValues.secret` |**None**|**Type:** `boolean`<br/>|
+| `apps.nodeExporter.dependsOn` |**None**|**Type:** `string`<br/>|
+| `apps.nodeExporter.extraConfigs` |**None**|**Type:** `array`<br/>|
+| `apps.nodeExporter.extraConfigs[*]` |**None**||
+| `apps.nodeExporter.extraConfigs[*].kind` |**None**|**Type:** `string`<br/>|
+| `apps.nodeExporter.extraConfigs[*].name` |**None**|**Type:** `string`<br/>|
+| `apps.nodeExporter.forceUpgrade` |**None**|**Type:** `boolean`<br/>|
+| `apps.nodeExporter.inCluster` |**None**|**Type:** `boolean`<br/>|
+| `apps.nodeExporter.namespace` |**None**|**Type:** `string`<br/>|
+| `apps.nodeExporter.version` |**None**|**Type:** `string`<br/>|
+| `apps.observabilityBundle` |**None**|**Type:** `object`<br/>|
+| `apps.observabilityBundle.appName` |**None**|**Type:** `string`<br/>|
+| `apps.observabilityBundle.catalog` |**None**|**Type:** `string`<br/>|
+| `apps.observabilityBundle.chartName` |**None**|**Type:** `string`<br/>|
+| `apps.observabilityBundle.clusterValues` |**None**|**Type:** `object`<br/>|
+| `apps.observabilityBundle.clusterValues.configMap` |**None**|**Type:** `boolean`<br/>|
+| `apps.observabilityBundle.clusterValues.secret` |**None**|**Type:** `boolean`<br/>|
+| `apps.observabilityBundle.dependsOn` |**None**|**Type:** `string`<br/>|
+| `apps.observabilityBundle.extraConfigs` |**None**|**Type:** `array`<br/>|
+| `apps.observabilityBundle.extraConfigs[*]` |**None**||
+| `apps.observabilityBundle.extraConfigs[*].kind` |**None**|**Type:** `string`<br/>|
+| `apps.observabilityBundle.extraConfigs[*].name` |**None**|**Type:** `string`<br/>|
+| `apps.observabilityBundle.forceUpgrade` |**None**|**Type:** `boolean`<br/>|
+| `apps.observabilityBundle.inCluster` |**None**|**Type:** `boolean`<br/>|
+| `apps.observabilityBundle.namespace` |**None**|**Type:** `string`<br/>|
+| `apps.observabilityBundle.version` |**None**|**Type:** `string`<br/>|
+| `apps.teleport-kube-agent` |**None**|**Type:** `object`<br/>|
+| `apps.teleport-kube-agent.appName` |**None**|**Type:** `string`<br/>|
+| `apps.teleport-kube-agent.catalog` |**None**|**Type:** `string`<br/>|
+| `apps.teleport-kube-agent.chartName` |**None**|**Type:** `string`<br/>|
+| `apps.teleport-kube-agent.clusterValues` |**None**|**Type:** `object`<br/>|
+| `apps.teleport-kube-agent.clusterValues.configMap` |**None**|**Type:** `boolean`<br/>|
+| `apps.teleport-kube-agent.clusterValues.secret` |**None**|**Type:** `boolean`<br/>|
+| `apps.teleport-kube-agent.dependsOn` |**None**|**Type:** `string`<br/>|
+| `apps.teleport-kube-agent.extraConfigs` |**None**|**Type:** `array`<br/>|
+| `apps.teleport-kube-agent.extraConfigs[*]` |**None**||
+| `apps.teleport-kube-agent.extraConfigs[*].kind` |**None**|**Type:** `string`<br/>|
+| `apps.teleport-kube-agent.extraConfigs[*].name` |**None**|**Type:** `string`<br/>|
+| `apps.teleport-kube-agent.forceUpgrade` |**None**|**Type:** `boolean`<br/>|
+| `apps.teleport-kube-agent.inCluster` |**None**|**Type:** `boolean`<br/>|
+| `apps.teleport-kube-agent.namespace` |**None**|**Type:** `string`<br/>|
+| `apps.teleport-kube-agent.version` |**None**|**Type:** `string`<br/>|
+
+### User Config
+
+Properties within the `.userConfig` top-level object
+
+| **Property** | **Description** | **More Details** |
+| :----------- | :-------------- | :--------------- |
+| `userConfig.certExporter` |**None**|**Type:** `object`<br/>|
+| `userConfig.certExporter.configMap` |**None**|**Type:** `object`<br/>|
+| `userConfig.certExporter.configMap.values` |**None**|**Types:** `object, string`<br/>|
+| `userConfig.certManager` |**None**|**Type:** `object`<br/>|
+| `userConfig.certManager.configMap` |**None**|**Type:** `object`<br/>|
+| `userConfig.certManager.configMap.values` |**None**|**Types:** `object, string`<br/>|
+| `userConfig.metricsServer` |**None**|**Type:** `object`<br/>|
+| `userConfig.metricsServer.configMap` |**None**|**Type:** `object`<br/>|
+| `userConfig.metricsServer.configMap.values` |**None**|**Types:** `object, string`<br/>|
+| `userConfig.netExporter` |**None**|**Type:** `object`<br/>|
+| `userConfig.netExporter.configMap` |**None**|**Type:** `object`<br/>|
+| `userConfig.netExporter.configMap.values` |**None**|**Types:** `object, string`<br/>|
+| `userConfig.nodeExporter` |**None**|**Type:** `object`<br/>|
+| `userConfig.nodeExporter.configMap` |**None**|**Type:** `object`<br/>|
+| `userConfig.nodeExporter.configMap.values` |**None**|**Types:** `object, string`<br/>|
+| `userConfig.vpa` |**None**|**Type:** `object`<br/>|
+| `userConfig.vpa.configMap` |**None**|**Type:** `object`<br/>|
+| `userConfig.vpa.configMap.values` |**None**|**Types:** `object, string`<br/>|
+
+### Other
+
+| **Property** | **Description** | **More Details** |
+| :----------- | :-------------- | :--------------- |
+| `clusterName` |**None**|**Type:** `string`<br/>|
+| `managementCluster` |**None**|**Type:** `string`<br/>|
+| `organization` |**None**|**Type:** `string`<br/>|
+
+<!-- DOCS_END -->


### PR DESCRIPTION
This PR:

Towards https://github.com/giantswarm/giantswarm/issues/29628

I want to add a Chart README to be embedded in our docs based on the [schemadocs](https://github.com/giantswarm/schemadocs) project

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.

### Testing

Description on how default-apps-vsphere can be tested.

- [ ] fresh install works
- [ ] upgrade from previous version works

### Trigger e2e tests

<!--
We currently have one pipeline that tests both cluster creation and cluster upgrades. You can trigger this pipeline by writing this commands in a pull request comment or description
- `/run cluster-test-suites`

If for some reason you want to skip the e2e tests, remove the following line.
-->

/run cluster-test-suites
