### PR TITLE
Prepare 1.25 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `security-bundle` app.
+ 
 ## [0.12.1] - 2024-02-12
 
 ### Added

--- a/helm/default-apps-vsphere/values.yaml
+++ b/helm/default-apps-vsphere/values.yaml
@@ -161,7 +161,7 @@ apps:
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/security-bundle
-    version: 0.21.0
+    version: 1.6.2
   vpa:
     appName: vertical-pod-autoscaler
     chartName: vertical-pod-autoscaler-app

--- a/helm/default-apps-vsphere/values.yaml
+++ b/helm/default-apps-vsphere/values.yaml
@@ -149,6 +149,19 @@ apps:
     # used by renovate
     # repo: giantswarm/observability-bundle
     version: 1.2.3
+  securityBundle:
+    appName: security-bundle
+    chartName: security-bundle
+    catalog: giantswarm
+    clusterValues:
+      configMap: true
+      secret: false
+    forceUpgrade: false
+    inCluster: true
+    namespace: kube-system
+    # used by renovate
+    # repo: giantswarm/security-bundle
+    version: 0.21.0
   vpa:
     appName: vertical-pod-autoscaler
     chartName: vertical-pod-autoscaler-app


### PR DESCRIPTION
This PR:

- adds the security bundle in version 1.6.2

Towards: https://github.com/giantswarm/giantswarm/issues/29849