### PR TITLE
Add capi-node-labeler app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `cilium-servicemonitors` app.
+- Add `capi-node-labeler` app.
 
 ## [0.13.0] - 2024-02-27
 

--- a/helm/default-apps-vsphere/values.schema.json
+++ b/helm/default-apps-vsphere/values.schema.json
@@ -75,6 +75,9 @@
         "apps": {
             "type": "object",
             "properties": {
+                "capi-node-labeler": {
+                    "$ref": "#/$defs/app"
+                },
                 "certExporter": {
                     "$ref": "#/$defs/app"
                 },

--- a/helm/default-apps-vsphere/values.yaml
+++ b/helm/default-apps-vsphere/values.yaml
@@ -51,6 +51,19 @@ userConfig:
           enabled: true
 
 apps:
+  capi-node-labeler:
+    appName: capi-node-labeler
+    chartName: capi-node-labeler
+    catalog: default
+    clusterValues:
+      configMap: true
+      secret: false
+    enabled: true
+    forceUpgrade: false
+    namespace: kube-system
+    # used by renovate
+    # repo: giantswarm/capi-node-labeler-app
+    version: 0.5.0
   certExporter:
     appName: cert-exporter
     chartName: cert-exporter


### PR DESCRIPTION
This PR:

- adds the `capi-node-labeler` app to properly set labels on nodes.

Towards: https://github.com/giantswarm/giantswarm/issues/30295

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.

/run cluster-test-suites
