### PR TITLE
Add flag to enable moving resources to cluster-vsphere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 > [!WARNING]
-> This release includes changes that enable the unification of cluster-vsphere and default-apps-vsphere. Workload cluster upgrade requires manual steps. See details below.
+> This release includes changes that enable the unification of cluster-vsphere and default-apps-vsphere. The unification
+> of cluster-vsphere and default-apps-vsphere does not happen automatically, it must be enabled explicitly and even then
+> it requires manual steps. See details below.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,7 +76,9 @@ kubectl delete -n giantswarm chart vertical-pod-autoscaler-crd
 The command line will probably hang, as the chart-operator finalizer has is not getting removed (vertical-pod-autoscaler-crd
 Chart CR has been paused). Proceed to the next step to remove the finalizer and unblock the deletion.
 
-3. Remove chart-operator finalizer from the vertical-pod-autoscaler-crd Chart CR
+3. Remove finalizers from the vertical-pod-autoscaler-crd Chart CR
+
+Open another terminal window and run the following command to remove the vertical-pod-autoscaler-crd Chart CR finalizers:
 
 ```shell
 kubectl patch chart vertical-pod-autoscaler-crd -n giantswarm --type=json -p='[{"op": "remove", "path": "/metadata/finalizers"}]'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+> [!WARNING]
+> This release includes changes that enable the unification of cluster-vsphere and default-apps-vsphere. Workload cluster upgrade requires manual steps. See details below.
+
 ### Added
 
 - Add `observability-policies` app.
+- New Helm value `.Values.deleteOptions.moveAppsHelmOwnershipToClusterVSphere`, which, when enabled, will pause all apps in the default-apps-vsphere, and it will enable the below hooks. The apps are paused in order to prevent the deletion of Chart resources in the WC.
+- Helm hook to remove app-operator finalizer from App CRs, so that App CRs are deleted from the MC, while Chart CRs stay on the WC.
+- Helm hook to propagate pause annotation to all bundled apps.
 
 ### Changed
 
@@ -22,6 +28,61 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update `observability-bundle` to v1.5.1.
 - Update `security-bundle` to v1.8.0.
 - Update `vertical-pod-autoscaler-app` to v5.2.4.
+
+### ⚠️ Workload cluster upgrade with manual steps
+
+The steps to upgrade a workload cluster, with unifying cluster-vsphere and default-apps-vsphere, are the following:
+- Upgrade default-apps-vsphere App to the latest release that includes this change.
+- Update default-apps-vsphere Helm value `.Values.deleteOptions.moveAppsHelmOwnershipToClusterVSphere` to `true`.
+  - All App CRs, except observability-bundle and security-bundle, will get `app-operator.giantswarm.io/paused: true` annotation,
+    so wait few minutes for Helm post-upgrade hook to apply the change to all required App CRs.
+- Delete default-apps-vsphere CR.
+  - ⚠️ In case you are removing default-apps-vsphere App CR from your gitops repo which is using Flux, and depending on
+    how Flux is configured, default-apps-vsphere App CR may or may not get deleted from the management cluster. In case
+    Flux does not delete default-apps-vsphere App CR from the management cluster, make sure to delete it manually.
+  - App CRs (on the MC) for all default apps will get deleted. Wait few minutes for this to happen.
+  - Chart CRs on the workload cluster will remain untouched, so all apps will continue running.
+- Upgrade cluster-vsphere App CR to the latest (TBA release which includes [these changes](https://github.com/giantswarm/cluster-vsphere/pull/262)).
+  - cluster-vsphere will deploy all default apps, so wait a few minutes for all Apps to be successfully deployed.
+  - Chart resources on the workload cluster will get updated, as newly deployed App resources will take over the reconciliation
+    of the existing Chart resources.
+
+We're almost there, with just one more issue to fix manually.
+
+VPA CRD used to installed as an App resource from default-apps-vsphere, and now it's being installed as a HelmRelease from
+cluster-vsphere. Now, as a consequence of the above upgrade, we have the following situation:
+- default-apps-vsphere App has been deleted, but the vertical-pod-autoscaler-crd Chart CRs remained in the workload cluster.
+- cluster-vsphere has been upgraded, so now it also installs vertical-pod-autoscaler-crd HelmRelease.
+- outcome: we now have vertical-pod-autoscaler-crd HelmRelease in the MC and vertical-pod-autoscaler-crd Chart CR in the WC.
+
+Now we will remove the leftover vertical-pod-autoscaler-crd Chart CR in a safe way:
+
+1. Pause vertical-pod-autoscaler-crd Chart CR.
+
+Add annotation `chart-operator.giantswarm.io/paused: "true"` to vertical-pod-autoscaler-crd Chart CR in the workload cluster:
+
+```sh
+kubectl annotate -n giantswarm chart vertical-pod-autoscaler-crd chart-operator.giantswarm.io/paused="true" --overwrite
+```
+
+2. Delete vertical-pod-autoscaler-crd Chart CR in the workload cluster.
+
+```shell
+kubectl delete -n giantswarm chart vertical-pod-autoscaler-crd
+```
+
+The command line will probably hang, as the chart-operator finalizer has is not getting removed (vertical-pod-autoscaler-crd
+Chart CR has been paused). Proceed to the next step to remove the finalizer and unblock the deletion.
+
+3. Remove chart-operator finalizer from the vertical-pod-autoscaler-crd Chart CR
+
+```shell
+kubectl patch chart vertical-pod-autoscaler-crd -n giantswarm --type=json -p='[{"op": "remove", "path": "/metadata/finalizers"}]'
+```
+
+This will unblock the deletion and vertical-pod-autoscaler-crd will get removed, **without actually deleting VPA CustomResourceDefinition**.
+
+From now on, VPA CustomResourceDefinition will be maintained by the vertical-pod-autoscaler HelmRelease on the management cluster.
 
 ## [0.15.0] - 2024-07-08
 

--- a/helm/default-apps-vsphere/README.md
+++ b/helm/default-apps-vsphere/README.md
@@ -1,191 +1,167 @@
-# Values schema documentation
+# default-apps-vsphere
 
-This page lists all available configuration options, based on the [configuration values schema](values.schema.json).
+![Version: 0.15.0](https://img.shields.io/badge/Version-0.15.0-informational?style=flat-square)
 
-<!-- DOCS_START -->
+A Helm chart which defines the pre-installed apps in all Giant Swarm vSphere clusters
 
-### Apps
+**Homepage:** <https://github.com/giantswarm/default-apps-vsphere>
 
-Properties within the `.apps` top-level object
+## Values
 
-| **Property** | **Description** | **More Details** |
-| :----------- | :-------------- | :--------------- |
-| `apps.capi-node-labeler` |**None**|**Type:** `object`<br/>|
-| `apps.capi-node-labeler.appName` |**None**|**Type:** `string`<br/>|
-| `apps.capi-node-labeler.catalog` |**None**|**Type:** `string`<br/>|
-| `apps.capi-node-labeler.chartName` |**None**|**Type:** `string`<br/>|
-| `apps.capi-node-labeler.clusterValues` |**None**|**Type:** `object`<br/>|
-| `apps.capi-node-labeler.clusterValues.configMap` |**None**|**Type:** `boolean`<br/>|
-| `apps.capi-node-labeler.clusterValues.secret` |**None**|**Type:** `boolean`<br/>|
-| `apps.capi-node-labeler.dependsOn` |**None**|**Type:** `string`<br/>|
-| `apps.capi-node-labeler.extraConfigs` |**None**|**Type:** `array`<br/>|
-| `apps.capi-node-labeler.extraConfigs[*]` |**None**||
-| `apps.capi-node-labeler.extraConfigs[*].kind` |**None**|**Type:** `string`<br/>|
-| `apps.capi-node-labeler.extraConfigs[*].name` |**None**|**Type:** `string`<br/>|
-| `apps.capi-node-labeler.forceUpgrade` |**None**|**Type:** `boolean`<br/>|
-| `apps.capi-node-labeler.inCluster` |**None**|**Type:** `boolean`<br/>|
-| `apps.capi-node-labeler.namespace` |**None**|**Type:** `string`<br/>|
-| `apps.capi-node-labeler.version` |**None**|**Type:** `string`<br/>|
-| `apps.certExporter` |**None**|**Type:** `object`<br/>|
-| `apps.certExporter.appName` |**None**|**Type:** `string`<br/>|
-| `apps.certExporter.catalog` |**None**|**Type:** `string`<br/>|
-| `apps.certExporter.chartName` |**None**|**Type:** `string`<br/>|
-| `apps.certExporter.clusterValues` |**None**|**Type:** `object`<br/>|
-| `apps.certExporter.clusterValues.configMap` |**None**|**Type:** `boolean`<br/>|
-| `apps.certExporter.clusterValues.secret` |**None**|**Type:** `boolean`<br/>|
-| `apps.certExporter.dependsOn` |**None**|**Type:** `string`<br/>|
-| `apps.certExporter.extraConfigs` |**None**|**Type:** `array`<br/>|
-| `apps.certExporter.extraConfigs[*]` |**None**||
-| `apps.certExporter.extraConfigs[*].kind` |**None**|**Type:** `string`<br/>|
-| `apps.certExporter.extraConfigs[*].name` |**None**|**Type:** `string`<br/>|
-| `apps.certExporter.forceUpgrade` |**None**|**Type:** `boolean`<br/>|
-| `apps.certExporter.inCluster` |**None**|**Type:** `boolean`<br/>|
-| `apps.certExporter.namespace` |**None**|**Type:** `string`<br/>|
-| `apps.certExporter.version` |**None**|**Type:** `string`<br/>|
-| `apps.chartOperatorExtensions` |**None**|**Type:** `object`<br/>|
-| `apps.chartOperatorExtensions.appName` |**None**|**Type:** `string`<br/>|
-| `apps.chartOperatorExtensions.catalog` |**None**|**Type:** `string`<br/>|
-| `apps.chartOperatorExtensions.chartName` |**None**|**Type:** `string`<br/>|
-| `apps.chartOperatorExtensions.clusterValues` |**None**|**Type:** `object`<br/>|
-| `apps.chartOperatorExtensions.clusterValues.configMap` |**None**|**Type:** `boolean`<br/>|
-| `apps.chartOperatorExtensions.clusterValues.secret` |**None**|**Type:** `boolean`<br/>|
-| `apps.chartOperatorExtensions.dependsOn` |**None**|**Type:** `string`<br/>|
-| `apps.chartOperatorExtensions.extraConfigs` |**None**|**Type:** `array`<br/>|
-| `apps.chartOperatorExtensions.extraConfigs[*]` |**None**||
-| `apps.chartOperatorExtensions.extraConfigs[*].kind` |**None**|**Type:** `string`<br/>|
-| `apps.chartOperatorExtensions.extraConfigs[*].name` |**None**|**Type:** `string`<br/>|
-| `apps.chartOperatorExtensions.forceUpgrade` |**None**|**Type:** `boolean`<br/>|
-| `apps.chartOperatorExtensions.inCluster` |**None**|**Type:** `boolean`<br/>|
-| `apps.chartOperatorExtensions.namespace` |**None**|**Type:** `string`<br/>|
-| `apps.chartOperatorExtensions.version` |**None**|**Type:** `string`<br/>|
-| `apps.ciliumServiceMonitors` |**None**|**Type:** `object`<br/>|
-| `apps.ciliumServiceMonitors.appName` |**None**|**Type:** `string`<br/>|
-| `apps.ciliumServiceMonitors.catalog` |**None**|**Type:** `string`<br/>|
-| `apps.ciliumServiceMonitors.chartName` |**None**|**Type:** `string`<br/>|
-| `apps.ciliumServiceMonitors.clusterValues` |**None**|**Type:** `object`<br/>|
-| `apps.ciliumServiceMonitors.clusterValues.configMap` |**None**|**Type:** `boolean`<br/>|
-| `apps.ciliumServiceMonitors.clusterValues.secret` |**None**|**Type:** `boolean`<br/>|
-| `apps.ciliumServiceMonitors.dependsOn` |**None**|**Type:** `string`<br/>|
-| `apps.ciliumServiceMonitors.extraConfigs` |**None**|**Type:** `array`<br/>|
-| `apps.ciliumServiceMonitors.extraConfigs[*]` |**None**||
-| `apps.ciliumServiceMonitors.extraConfigs[*].kind` |**None**|**Type:** `string`<br/>|
-| `apps.ciliumServiceMonitors.extraConfigs[*].name` |**None**|**Type:** `string`<br/>|
-| `apps.ciliumServiceMonitors.forceUpgrade` |**None**|**Type:** `boolean`<br/>|
-| `apps.ciliumServiceMonitors.inCluster` |**None**|**Type:** `boolean`<br/>|
-| `apps.ciliumServiceMonitors.namespace` |**None**|**Type:** `string`<br/>|
-| `apps.ciliumServiceMonitors.version` |**None**|**Type:** `string`<br/>|
-| `apps.clusterResources` |**None**|**Type:** `object`<br/>|
-| `apps.clusterResources.appName` |**None**|**Type:** `string`<br/>|
-| `apps.clusterResources.catalog` |**None**|**Type:** `string`<br/>|
-| `apps.clusterResources.chartName` |**None**|**Type:** `string`<br/>|
-| `apps.clusterResources.clusterValues` |**None**|**Type:** `object`<br/>|
-| `apps.clusterResources.clusterValues.configMap` |**None**|**Type:** `boolean`<br/>|
-| `apps.clusterResources.clusterValues.secret` |**None**|**Type:** `boolean`<br/>|
-| `apps.clusterResources.dependsOn` |**None**|**Type:** `string`<br/>|
-| `apps.clusterResources.extraConfigs` |**None**|**Type:** `array`<br/>|
-| `apps.clusterResources.extraConfigs[*]` |**None**||
-| `apps.clusterResources.extraConfigs[*].kind` |**None**|**Type:** `string`<br/>|
-| `apps.clusterResources.extraConfigs[*].name` |**None**|**Type:** `string`<br/>|
-| `apps.clusterResources.forceUpgrade` |**None**|**Type:** `boolean`<br/>|
-| `apps.clusterResources.inCluster` |**None**|**Type:** `boolean`<br/>|
-| `apps.clusterResources.namespace` |**None**|**Type:** `string`<br/>|
-| `apps.clusterResources.version` |**None**|**Type:** `string`<br/>|
-| `apps.metricsServer` |**None**|**Type:** `object`<br/>|
-| `apps.metricsServer.appName` |**None**|**Type:** `string`<br/>|
-| `apps.metricsServer.catalog` |**None**|**Type:** `string`<br/>|
-| `apps.metricsServer.chartName` |**None**|**Type:** `string`<br/>|
-| `apps.metricsServer.clusterValues` |**None**|**Type:** `object`<br/>|
-| `apps.metricsServer.clusterValues.configMap` |**None**|**Type:** `boolean`<br/>|
-| `apps.metricsServer.clusterValues.secret` |**None**|**Type:** `boolean`<br/>|
-| `apps.metricsServer.dependsOn` |**None**|**Type:** `string`<br/>|
-| `apps.metricsServer.extraConfigs` |**None**|**Type:** `array`<br/>|
-| `apps.metricsServer.extraConfigs[*]` |**None**||
-| `apps.metricsServer.extraConfigs[*].kind` |**None**|**Type:** `string`<br/>|
-| `apps.metricsServer.extraConfigs[*].name` |**None**|**Type:** `string`<br/>|
-| `apps.metricsServer.forceUpgrade` |**None**|**Type:** `boolean`<br/>|
-| `apps.metricsServer.inCluster` |**None**|**Type:** `boolean`<br/>|
-| `apps.metricsServer.namespace` |**None**|**Type:** `string`<br/>|
-| `apps.metricsServer.version` |**None**|**Type:** `string`<br/>|
-| `apps.nodeExporter` |**None**|**Type:** `object`<br/>|
-| `apps.nodeExporter.appName` |**None**|**Type:** `string`<br/>|
-| `apps.nodeExporter.catalog` |**None**|**Type:** `string`<br/>|
-| `apps.nodeExporter.chartName` |**None**|**Type:** `string`<br/>|
-| `apps.nodeExporter.clusterValues` |**None**|**Type:** `object`<br/>|
-| `apps.nodeExporter.clusterValues.configMap` |**None**|**Type:** `boolean`<br/>|
-| `apps.nodeExporter.clusterValues.secret` |**None**|**Type:** `boolean`<br/>|
-| `apps.nodeExporter.dependsOn` |**None**|**Type:** `string`<br/>|
-| `apps.nodeExporter.extraConfigs` |**None**|**Type:** `array`<br/>|
-| `apps.nodeExporter.extraConfigs[*]` |**None**||
-| `apps.nodeExporter.extraConfigs[*].kind` |**None**|**Type:** `string`<br/>|
-| `apps.nodeExporter.extraConfigs[*].name` |**None**|**Type:** `string`<br/>|
-| `apps.nodeExporter.forceUpgrade` |**None**|**Type:** `boolean`<br/>|
-| `apps.nodeExporter.inCluster` |**None**|**Type:** `boolean`<br/>|
-| `apps.nodeExporter.namespace` |**None**|**Type:** `string`<br/>|
-| `apps.nodeExporter.version` |**None**|**Type:** `string`<br/>|
-| `apps.observabilityBundle` |**None**|**Type:** `object`<br/>|
-| `apps.observabilityBundle.appName` |**None**|**Type:** `string`<br/>|
-| `apps.observabilityBundle.catalog` |**None**|**Type:** `string`<br/>|
-| `apps.observabilityBundle.chartName` |**None**|**Type:** `string`<br/>|
-| `apps.observabilityBundle.clusterValues` |**None**|**Type:** `object`<br/>|
-| `apps.observabilityBundle.clusterValues.configMap` |**None**|**Type:** `boolean`<br/>|
-| `apps.observabilityBundle.clusterValues.secret` |**None**|**Type:** `boolean`<br/>|
-| `apps.observabilityBundle.dependsOn` |**None**|**Type:** `string`<br/>|
-| `apps.observabilityBundle.extraConfigs` |**None**|**Type:** `array`<br/>|
-| `apps.observabilityBundle.extraConfigs[*]` |**None**||
-| `apps.observabilityBundle.extraConfigs[*].kind` |**None**|**Type:** `string`<br/>|
-| `apps.observabilityBundle.extraConfigs[*].name` |**None**|**Type:** `string`<br/>|
-| `apps.observabilityBundle.forceUpgrade` |**None**|**Type:** `boolean`<br/>|
-| `apps.observabilityBundle.inCluster` |**None**|**Type:** `boolean`<br/>|
-| `apps.observabilityBundle.namespace` |**None**|**Type:** `string`<br/>|
-| `apps.observabilityBundle.version` |**None**|**Type:** `string`<br/>|
-| `apps.teleport-kube-agent` |**None**|**Type:** `object`<br/>|
-| `apps.teleport-kube-agent.appName` |**None**|**Type:** `string`<br/>|
-| `apps.teleport-kube-agent.catalog` |**None**|**Type:** `string`<br/>|
-| `apps.teleport-kube-agent.chartName` |**None**|**Type:** `string`<br/>|
-| `apps.teleport-kube-agent.clusterValues` |**None**|**Type:** `object`<br/>|
-| `apps.teleport-kube-agent.clusterValues.configMap` |**None**|**Type:** `boolean`<br/>|
-| `apps.teleport-kube-agent.clusterValues.secret` |**None**|**Type:** `boolean`<br/>|
-| `apps.teleport-kube-agent.dependsOn` |**None**|**Type:** `string`<br/>|
-| `apps.teleport-kube-agent.extraConfigs` |**None**|**Type:** `array`<br/>|
-| `apps.teleport-kube-agent.extraConfigs[*]` |**None**||
-| `apps.teleport-kube-agent.extraConfigs[*].kind` |**None**|**Type:** `string`<br/>|
-| `apps.teleport-kube-agent.extraConfigs[*].name` |**None**|**Type:** `string`<br/>|
-| `apps.teleport-kube-agent.forceUpgrade` |**None**|**Type:** `boolean`<br/>|
-| `apps.teleport-kube-agent.inCluster` |**None**|**Type:** `boolean`<br/>|
-| `apps.teleport-kube-agent.namespace` |**None**|**Type:** `string`<br/>|
-| `apps.teleport-kube-agent.version` |**None**|**Type:** `string`<br/>|
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| apps.capi-node-labeler.appName | string | `"capi-node-labeler"` |  |
+| apps.capi-node-labeler.catalog | string | `"default"` |  |
+| apps.capi-node-labeler.chartName | string | `"capi-node-labeler"` |  |
+| apps.capi-node-labeler.clusterValues.configMap | bool | `true` |  |
+| apps.capi-node-labeler.clusterValues.secret | bool | `false` |  |
+| apps.capi-node-labeler.forceUpgrade | bool | `false` |  |
+| apps.capi-node-labeler.namespace | string | `"kube-system"` |  |
+| apps.capi-node-labeler.version | string | `"0.5.0"` |  |
+| apps.certExporter.appName | string | `"cert-exporter"` |  |
+| apps.certExporter.catalog | string | `"default"` |  |
+| apps.certExporter.chartName | string | `"cert-exporter"` |  |
+| apps.certExporter.clusterValues.configMap | bool | `true` |  |
+| apps.certExporter.clusterValues.secret | bool | `false` |  |
+| apps.certExporter.forceUpgrade | bool | `true` |  |
+| apps.certExporter.namespace | string | `"kube-system"` |  |
+| apps.certExporter.version | string | `"2.9.1"` |  |
+| apps.certManager.appName | string | `"cert-manager"` |  |
+| apps.certManager.catalog | string | `"default"` |  |
+| apps.certManager.chartName | string | `"cert-manager-app"` |  |
+| apps.certManager.clusterValues.configMap | bool | `true` |  |
+| apps.certManager.clusterValues.secret | bool | `true` |  |
+| apps.certManager.dependsOn | string | `"prometheus-operator-crd"` |  |
+| apps.certManager.forceUpgrade | bool | `true` |  |
+| apps.certManager.namespace | string | `"kube-system"` |  |
+| apps.certManager.version | string | `"3.8.1"` |  |
+| apps.chartOperatorExtensions.appName | string | `"chart-operator-extensions"` |  |
+| apps.chartOperatorExtensions.catalog | string | `"default"` |  |
+| apps.chartOperatorExtensions.chartName | string | `"chart-operator-extensions"` |  |
+| apps.chartOperatorExtensions.clusterValues.configMap | bool | `false` |  |
+| apps.chartOperatorExtensions.clusterValues.secret | bool | `false` |  |
+| apps.chartOperatorExtensions.dependsOn | string | `"prometheus-operator-crd"` |  |
+| apps.chartOperatorExtensions.namespace | string | `"giantswarm"` |  |
+| apps.chartOperatorExtensions.version | string | `"1.1.2"` |  |
+| apps.ciliumServiceMonitors.appName | string | `"cilium-servicemonitors"` |  |
+| apps.ciliumServiceMonitors.catalog | string | `"default"` |  |
+| apps.ciliumServiceMonitors.chartName | string | `"cilium-servicemonitors"` |  |
+| apps.ciliumServiceMonitors.clusterValues.configMap | bool | `false` |  |
+| apps.ciliumServiceMonitors.clusterValues.secret | bool | `false` |  |
+| apps.ciliumServiceMonitors.dependsOn | string | `"prometheus-operator-crd"` |  |
+| apps.ciliumServiceMonitors.namespace | string | `"kube-system"` |  |
+| apps.ciliumServiceMonitors.version | string | `"0.1.2"` |  |
+| apps.etcdKubernetesResourceCountExporter.appName | string | `"etcd-k8s-res-count-exporter"` |  |
+| apps.etcdKubernetesResourceCountExporter.catalog | string | `"default"` |  |
+| apps.etcdKubernetesResourceCountExporter.chartName | string | `"etcd-kubernetes-resources-count-exporter"` |  |
+| apps.etcdKubernetesResourceCountExporter.clusterValues.configMap | bool | `true` |  |
+| apps.etcdKubernetesResourceCountExporter.clusterValues.secret | bool | `false` |  |
+| apps.etcdKubernetesResourceCountExporter.forceUpgrade | bool | `false` |  |
+| apps.etcdKubernetesResourceCountExporter.namespace | string | `"kube-system"` |  |
+| apps.etcdKubernetesResourceCountExporter.version | string | `"1.10.0"` |  |
+| apps.k8sDnsNodeCache.appName | string | `"k8s-dns-node-cache"` |  |
+| apps.k8sDnsNodeCache.catalog | string | `"default"` |  |
+| apps.k8sDnsNodeCache.chartName | string | `"k8s-dns-node-cache-app"` |  |
+| apps.k8sDnsNodeCache.namespace | string | `"kube-system"` |  |
+| apps.k8sDnsNodeCache.version | string | `"2.8.1"` |  |
+| apps.metricsServer.appName | string | `"metrics-server"` |  |
+| apps.metricsServer.catalog | string | `"default"` |  |
+| apps.metricsServer.chartName | string | `"metrics-server-app"` |  |
+| apps.metricsServer.clusterValues.configMap | bool | `true` |  |
+| apps.metricsServer.clusterValues.secret | bool | `false` |  |
+| apps.metricsServer.forceUpgrade | bool | `true` |  |
+| apps.metricsServer.namespace | string | `"kube-system"` |  |
+| apps.metricsServer.version | string | `"2.4.2"` |  |
+| apps.netExporter.appName | string | `"net-exporter"` |  |
+| apps.netExporter.catalog | string | `"default"` |  |
+| apps.netExporter.chartName | string | `"net-exporter"` |  |
+| apps.netExporter.clusterValues.configMap | bool | `true` |  |
+| apps.netExporter.clusterValues.secret | bool | `false` |  |
+| apps.netExporter.forceUpgrade | bool | `true` |  |
+| apps.netExporter.namespace | string | `"kube-system"` |  |
+| apps.netExporter.version | string | `"1.21.0"` |  |
+| apps.nodeExporter.appName | string | `"node-exporter"` |  |
+| apps.nodeExporter.catalog | string | `"default"` |  |
+| apps.nodeExporter.chartName | string | `"node-exporter-app"` |  |
+| apps.nodeExporter.clusterValues.configMap | bool | `true` |  |
+| apps.nodeExporter.clusterValues.secret | bool | `false` |  |
+| apps.nodeExporter.forceUpgrade | bool | `true` |  |
+| apps.nodeExporter.namespace | string | `"kube-system"` |  |
+| apps.nodeExporter.version | string | `"1.19.0"` |  |
+| apps.observabilityBundle.appName | string | `"observability-bundle"` |  |
+| apps.observabilityBundle.catalog | string | `"default"` |  |
+| apps.observabilityBundle.chartName | string | `"observability-bundle"` |  |
+| apps.observabilityBundle.clusterValues.configMap | bool | `true` |  |
+| apps.observabilityBundle.clusterValues.secret | bool | `false` |  |
+| apps.observabilityBundle.forceUpgrade | bool | `false` |  |
+| apps.observabilityBundle.inCluster | bool | `true` |  |
+| apps.observabilityBundle.namespace | string | `"kube-system"` |  |
+| apps.observabilityBundle.version | string | `"1.5.2"` |  |
+| apps.observabilityPolicies.appName | string | `"observability-policies"` |  |
+| apps.observabilityPolicies.catalog | string | `"default"` |  |
+| apps.observabilityPolicies.chartName | string | `"observability-policies"` |  |
+| apps.observabilityPolicies.clusterValues.configMap | bool | `false` |  |
+| apps.observabilityPolicies.clusterValues.secret | bool | `false` |  |
+| apps.observabilityPolicies.dependsOn | string | `"kyverno-crds"` |  |
+| apps.observabilityPolicies.namespace | string | `"kube-system"` |  |
+| apps.observabilityPolicies.version | string | `"0.0.1"` |  |
+| apps.securityBundle.appName | string | `"security-bundle"` |  |
+| apps.securityBundle.catalog | string | `"giantswarm"` |  |
+| apps.securityBundle.chartName | string | `"security-bundle"` |  |
+| apps.securityBundle.clusterValues.configMap | bool | `true` |  |
+| apps.securityBundle.clusterValues.secret | bool | `false` |  |
+| apps.securityBundle.forceUpgrade | bool | `false` |  |
+| apps.securityBundle.inCluster | bool | `true` |  |
+| apps.securityBundle.namespace | string | `"kube-system"` |  |
+| apps.securityBundle.version | string | `"1.8.0"` |  |
+| apps.teleport-kube-agent.appName | string | `"teleport-kube-agent"` |  |
+| apps.teleport-kube-agent.catalog | string | `"default"` |  |
+| apps.teleport-kube-agent.chartName | string | `"teleport-kube-agent"` |  |
+| apps.teleport-kube-agent.clusterValues.configMap | bool | `true` |  |
+| apps.teleport-kube-agent.clusterValues.secret | bool | `true` |  |
+| apps.teleport-kube-agent.extraConfigs[0].kind | string | `"configMap"` |  |
+| apps.teleport-kube-agent.extraConfigs[0].name | string | `"{{ $.Values.clusterName }}-teleport-kube-agent-config"` |  |
+| apps.teleport-kube-agent.extraConfigs[0].namespace | string | `"{{ $.Release.Namespace }}"` |  |
+| apps.teleport-kube-agent.forceUpgrade | bool | `true` |  |
+| apps.teleport-kube-agent.namespace | string | `"kube-system"` |  |
+| apps.teleport-kube-agent.version | string | `"0.9.2"` |  |
+| apps.vpa.appName | string | `"vertical-pod-autoscaler"` |  |
+| apps.vpa.catalog | string | `"default"` |  |
+| apps.vpa.chartName | string | `"vertical-pod-autoscaler-app"` |  |
+| apps.vpa.clusterValues.configMap | bool | `true` |  |
+| apps.vpa.clusterValues.secret | bool | `false` |  |
+| apps.vpa.dependsOn | string | `"vertical-pod-autoscaler-crd"` |  |
+| apps.vpa.forceUpgrade | bool | `false` |  |
+| apps.vpa.namespace | string | `"kube-system"` |  |
+| apps.vpa.version | string | `"5.2.4"` |  |
+| apps.vpaCRD.appName | string | `"vertical-pod-autoscaler-crd"` |  |
+| apps.vpaCRD.catalog | string | `"default"` |  |
+| apps.vpaCRD.chartName | string | `"vertical-pod-autoscaler-crd"` |  |
+| apps.vpaCRD.clusterValues.configMap | bool | `true` |  |
+| apps.vpaCRD.clusterValues.secret | bool | `false` |  |
+| apps.vpaCRD.forceUpgrade | bool | `false` |  |
+| apps.vpaCRD.namespace | string | `"kube-system"` |  |
+| apps.vpaCRD.version | string | `"3.1.0"` |  |
+| clusterName | string | `""` |  |
+| managementCluster | string | `""` |  |
+| organization | string | `""` |  |
+| userConfig.certExporter.configMap.values.ciliumNetworkPolicy.enabled | bool | `true` |  |
+| userConfig.certManager.configMap.values.ciliumNetworkPolicy.enabled | bool | `true` |  |
+| userConfig.certManager.configMap.values.enableServiceLinks | bool | `true` |  |
+| userConfig.certManager.configMap.values.ingressShim.defaultIssuerGroup | string | `"cert-manager.io"` |  |
+| userConfig.certManager.configMap.values.ingressShim.defaultIssuerKind | string | `"ClusterIssuer"` |  |
+| userConfig.certManager.configMap.values.ingressShim.defaultIssuerName | string | `"letsencrypt-giantswarm"` |  |
+| userConfig.etcdKubernetesResourceCountExporter.configMap.values.etcd.cacertpath | string | `"/certs/ca.crt"` |  |
+| userConfig.etcdKubernetesResourceCountExporter.configMap.values.etcd.certpath | string | `"/certs/server.crt"` |  |
+| userConfig.etcdKubernetesResourceCountExporter.configMap.values.etcd.hostPath | string | `"/etc/kubernetes/pki/etcd/"` |  |
+| userConfig.etcdKubernetesResourceCountExporter.configMap.values.etcd.keypath | string | `"/certs/server.key"` |  |
+| userConfig.etcdKubernetesResourceCountExporter.configMap.values.etcd.prefix | string | `"/registry/"` |  |
+| userConfig.etcdKubernetesResourceCountExporter.configMap.values.events.prefix | string | `"/registry/events/"` |  |
+| userConfig.metricsServer.configMap.values.ciliumNetworkPolicy.enabled | bool | `true` |  |
+| userConfig.netExporter.configMap.values.ciliumNetworkPolicy.enabled | bool | `true` |  |
+| userConfig.nodeExporter.configMap.values.disableConntrackCollector | bool | `true` |  |
+| userConfig.nodeExporter.configMap.values.disableNvmeCollector | bool | `true` |  |
+| userConfig.vpa.configMap.values.ciliumNetworkPolicy.enabled | bool | `true` |  |
 
-### User Config
-
-Properties within the `.userConfig` top-level object
-
-| **Property** | **Description** | **More Details** |
-| :----------- | :-------------- | :--------------- |
-| `userConfig.certExporter` |**None**|**Type:** `object`<br/>|
-| `userConfig.certExporter.configMap` |**None**|**Type:** `object`<br/>|
-| `userConfig.certExporter.configMap.values` |**None**|**Types:** `object, string`<br/>|
-| `userConfig.certManager` |**None**|**Type:** `object`<br/>|
-| `userConfig.certManager.configMap` |**None**|**Type:** `object`<br/>|
-| `userConfig.certManager.configMap.values` |**None**|**Types:** `object, string`<br/>|
-| `userConfig.metricsServer` |**None**|**Type:** `object`<br/>|
-| `userConfig.metricsServer.configMap` |**None**|**Type:** `object`<br/>|
-| `userConfig.metricsServer.configMap.values` |**None**|**Types:** `object, string`<br/>|
-| `userConfig.netExporter` |**None**|**Type:** `object`<br/>|
-| `userConfig.netExporter.configMap` |**None**|**Type:** `object`<br/>|
-| `userConfig.netExporter.configMap.values` |**None**|**Types:** `object, string`<br/>|
-| `userConfig.nodeExporter` |**None**|**Type:** `object`<br/>|
-| `userConfig.nodeExporter.configMap` |**None**|**Type:** `object`<br/>|
-| `userConfig.nodeExporter.configMap.values` |**None**|**Types:** `object, string`<br/>|
-| `userConfig.vpa` |**None**|**Type:** `object`<br/>|
-| `userConfig.vpa.configMap` |**None**|**Type:** `object`<br/>|
-| `userConfig.vpa.configMap.values` |**None**|**Types:** `object, string`<br/>|
-
-### Other
-
-| **Property** | **Description** | **More Details** |
-| :----------- | :-------------- | :--------------- |
-| `clusterName` |**None**|**Type:** `string`<br/>|
-| `managementCluster` |**None**|**Type:** `string`<br/>|
-| `organization` |**None**|**Type:** `string`<br/>|
-
-<!-- DOCS_END -->
+----------------------------------------------
+Autogenerated from chart metadata using [helm-docs v1.11.0](https://github.com/norwoodj/helm-docs/releases/v1.11.0)

--- a/helm/default-apps-vsphere/templates/apps.yaml
+++ b/helm/default-apps-vsphere/templates/apps.yaml
@@ -10,6 +10,11 @@ metadata:
     # app-operator will make sure that the app on which it depends is installed before
     app-operator.giantswarm.io/depends-on: {{ printf "%s-%s" $.Values.clusterName .dependsOn -}}
     {{- end }}
+    {{- if and $.Values.deleteOptions.moveAppsHelmOwnershipToClusterVSphere (not .inCluster) }}
+    {{- /* We add pause annotation to all apps except bundles (.inCluster==true), because we
+           delete bundles from the MC in order to trigger correct deletion of bundled apps. */}}
+    app-operator.giantswarm.io/paused: "true"
+    {{- end }}
   labels:
     {{- include "labels.common" $ | nindent 4 }}
     {{- if .inCluster }}  

--- a/helm/default-apps-vsphere/templates/move-apps-to-cluster-vsphere.yaml
+++ b/helm/default-apps-vsphere/templates/move-apps-to-cluster-vsphere.yaml
@@ -1,0 +1,117 @@
+{{- if .Values.deleteOptions.moveAppsHelmOwnershipToClusterVSphere }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $.Values.clusterName }}-move-apps-to-cluster-vsphere
+  namespace: "{{ $.Release.Namespace }}"
+  annotations:
+    "helm.sh/hook": "post-delete"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+    "helm.sh/hook-weight": "-1"
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $.Values.clusterName }}-move-apps-to-cluster-vsphere
+  namespace: "{{ $.Release.Namespace }}"
+  annotations:
+    "helm.sh/hook": "post-delete"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+    "helm.sh/hook-weight": "-1"
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+rules:
+- apiGroups: ["application.giantswarm.io"]
+  resources: ["apps"]
+  verbs: ["get", "list", "patch", "update"]
+- apiGroups: [""]
+  resources: ["configmaps", "secrets"]
+  verbs: ["get", "list", "patch", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $.Values.clusterName }}-move-apps-to-cluster-vsphere
+  namespace: "{{ $.Release.Namespace }}"
+  annotations:
+    "helm.sh/hook": "post-delete"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+    "helm.sh/hook-weight": "-1"
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+subjects:
+- kind: ServiceAccount
+  name: {{ $.Values.clusterName }}-move-apps-to-cluster-vsphere
+  namespace: "{{ $.Release.Namespace }}"
+roleRef:
+  kind: Role
+  name: {{ $.Values.clusterName }}-move-apps-to-cluster-vsphere
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $.Values.clusterName }}-move-apps-to-cluster-vsphere
+  namespace: "{{ $.Release.Namespace }}"
+  annotations:
+    "helm.sh/hook": "post-delete"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+    "helm.sh/hook-weight": "0"
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+spec:
+  ttlSecondsAfterFinished: 2592000 # 30 days
+  template:
+    metadata:
+      name: {{ $.Values.clusterName }}-move-apps-to-cluster-vsphere
+      namespace: "{{ $.Release.Namespace }}"
+      labels:
+        {{- include "labels.common" $ | nindent 8 }}
+    spec:
+      restartPolicy: Never
+      serviceAccountName: {{ $.Values.clusterName }}-move-apps-to-cluster-vsphere
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: remove-app-operator-finalizer
+        image: gsoci.azurecr.io/giantswarm/kubectl:1.29.7
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          runAsGroup: 65532
+          runAsUser: 65532
+        command:
+        - "/bin/sh"
+        - "-xc"
+        - |
+          NAMESPACE="{{ $.Release.Namespace }}"
+
+          echo "Remove app-operator finalizer for all Apps owned by default-apps-vsphere (except bundles that we want to delete regularly)"
+          for app_name in $(kubectl get Apps -n $NAMESPACE -l giantswarm.io/cluster={{ $.Values.clusterName }},app.kubernetes.io/name=default-apps-vsphere,giantswarm.io/managed-by={{ $.Values.clusterName }}-default-apps -o name); do
+            case "$app_name" in
+              *bundle*)
+                echo "do nothing for bundles"
+                ;;
+              *)
+                kubectl patch -n $NAMESPACE $app_name --type=merge -p '{"metadata": {"finalizers": null}}'
+                ;;
+            esac
+          done
+
+          echo "Remove app-operator finalizer from all observability-bundle apps"
+          for app_name in $(kubectl get Apps -n $NAMESPACE -l giantswarm.io/cluster={{ $.Values.clusterName }},giantswarm.io/managed-by={{ $.Values.clusterName }}-observability-bundle -o name); do
+            kubectl patch -n $NAMESPACE $app_name --type=merge -p '{"metadata": {"finalizers": null}}'
+          done
+
+          echo "Remove app-operator finalizer from all security-bundle apps"
+          for app_name in $(kubectl get Apps -n $NAMESPACE -l giantswarm.io/cluster={{ $.Values.clusterName }},giantswarm.io/managed-by={{ $.Values.clusterName }}-security-bundle -o name); do
+            kubectl patch -n $NAMESPACE $app_name --type=merge -p '{"metadata": {"finalizers": null}}'
+          done
+{{- end }}

--- a/helm/default-apps-vsphere/templates/propagate-pause-to-bundled-apps.yaml
+++ b/helm/default-apps-vsphere/templates/propagate-pause-to-bundled-apps.yaml
@@ -1,0 +1,105 @@
+{{- if .Values.deleteOptions.moveAppsHelmOwnershipToClusterVSphere }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $.Values.clusterName }}-propagate-pause
+  namespace: "{{ $.Release.Namespace }}"
+  annotations:
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+    "helm.sh/hook-weight": "-1"
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $.Values.clusterName }}-propagate-pause
+  namespace: "{{ $.Release.Namespace }}"
+  annotations:
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+    "helm.sh/hook-weight": "-1"
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+rules:
+- apiGroups: ["application.giantswarm.io"]
+  resources: ["apps"]
+  verbs: ["get", "list", "patch", "update"]
+- apiGroups: [""]
+  resources: ["configmaps", "secrets"]
+  verbs: ["get", "list", "patch", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $.Values.clusterName }}-propagate-pause
+  namespace: "{{ $.Release.Namespace }}"
+  annotations:
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+    "helm.sh/hook-weight": "-1"
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+subjects:
+- kind: ServiceAccount
+  name: {{ $.Values.clusterName }}-propagate-pause
+  namespace: "{{ $.Release.Namespace }}"
+roleRef:
+  kind: Role
+  name: {{ $.Values.clusterName }}-propagate-pause
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $.Values.clusterName }}-propagate-pause
+  namespace: "{{ $.Release.Namespace }}"
+  annotations:
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+    "helm.sh/hook-weight": "0"
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+spec:
+  ttlSecondsAfterFinished: 2592000 # 30 days
+  template:
+    metadata:
+      name: {{ $.Values.clusterName }}-propagate-pause
+      namespace: "{{ $.Release.Namespace }}"
+      labels:
+        {{- include "labels.common" $ | nindent 8 }}
+    spec:
+      restartPolicy: Never
+      serviceAccountName: {{ $.Values.clusterName }}-propagate-pause
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: propagate-pause
+        image: gsoci.azurecr.io/giantswarm/kubectl:1.29.7
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          runAsGroup: 65532
+          runAsUser: 65532
+        command:
+        - "/bin/sh"
+        - "-xc"
+        - |
+          NAMESPACE="{{ $.Release.Namespace }}"
+
+          echo "Add pause annotation to all observability-bundle apps"
+          for app_name in $(kubectl get Apps -n $NAMESPACE -l giantswarm.io/cluster={{ $.Values.clusterName }},giantswarm.io/managed-by={{ $.Values.clusterName }}-observability-bundle -o name); do
+            kubectl patch -n $NAMESPACE $app_name --type=merge -p '{"metadata": {"annotations": {"app-operator.giantswarm.io/paused": "true"}}}'
+          done
+
+          echo "Add pause annotation to all security-bundle apps"
+          for app_name in $(kubectl get Apps -n $NAMESPACE -l giantswarm.io/cluster={{ $.Values.clusterName }},giantswarm.io/managed-by={{ $.Values.clusterName }}-security-bundle -o name); do
+            kubectl patch -n $NAMESPACE $app_name --type=merge -p '{"metadata": {"annotations": {"app-operator.giantswarm.io/paused": "true"}}}'
+          done
+{{- end }}

--- a/helm/default-apps-vsphere/values.schema.json
+++ b/helm/default-apps-vsphere/values.schema.json
@@ -110,6 +110,18 @@
         "clusterName": {
             "type": "string"
         },
+        "deleteOptions": {
+            "type": "object",
+            "title": "Delete options",
+            "properties": {
+                "moveAppsHelmOwnershipToClusterVSphere": {
+                    "type": "boolean",
+                    "title": "Move Apps Helm ownership to cluster-vsphere",
+                    "description": "Don't delete Apps' Helm charts in the workload cluster. After the update, cluster-vsphere will recreate App CRs and new App CRs will take over the reconciliation of the existing Chart CRs in the workload cluster.",
+                    "default": false
+                }
+            }
+        },
         "managementCluster": {
             "type": "string"
         },

--- a/helm/default-apps-vsphere/values.yaml
+++ b/helm/default-apps-vsphere/values.yaml
@@ -2,6 +2,9 @@ clusterName: ""
 organization: ""
 managementCluster: ""
 
+deleteOptions:
+  moveAppsHelmOwnershipToClusterVSphere: false
+
 userConfig:
   certExporter:
     configMap:


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/3125

This PR adds:

- New Helm value `.Values.deleteOptions.moveAppsHelmOwnershipToClusterVSphere`, which, when enabled, will pause all apps in the default-apps-vsphere, and it will enable the below hooks. The apps are paused in order to prevent the deletion of Chart resources in the WC.
- Helm hook to remove app-operator finalizer from App CRs, so that App CRs are deleted from the MC, while Chart CRs stay on the WC.
- Helm hook to propagate pause annotation to all bundled apps.

The apps are then migrated from default-apps-vsphere to cluster-vsphere in the following way:
- Upgrade default-apps-vsphere App to the latest.
- Update default-apps-vsphere Helm value `.Values.deleteOptions.moveAppsHelmOwnershipToClusterVSphere` to true.
  - All apps, except observability-bundle and security-bundle will get `app-operator.giantswarm.io/paused: true` annotation, so wait few minutes for the change to get applied by the Helm post-upgrade hook.
- Delete default-apps-vsphere.
  - ⚠️ In case you are removing default-apps-vsphere from your gitops repo which is using Flux, depending on how Flux is configured default-apps-vsphere App may or may not get deleted from the management cluster. In case Flux does not delete default-apps-vsphere App, make sure to delete it manually from the management cluster.
  - App resources for all default apps will get deleted. Wait few minutes for this to happen.
  - Chart resources on the workload cluster will stay, so all apps will continue running. 
- Upgrade cluster-vsphere App to the latest (appropriate changes will be added to cluster-vsphere).
  - cluster-vsphere will deploy all default apps, wait a few minutes for all Apps to be successfully deployed.
  - Chart resources on the workload cluster will get updated, as newly deployed App resources will take over the reconciliation of the existing Chart resources.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.

### Testing

Description on how default-apps-vsphere can be tested.

- [x] fresh install works
- [x] upgrade from previous version works

### Trigger e2e tests

<!--
We currently have one pipeline that tests both cluster creation and cluster upgrades. You can trigger this pipeline by writing this commands in a pull request comment or description
- `/run cluster-test-suites`

If for some reason you want to skip the e2e tests, remove the following line.

Note: Tests are not automatically executed when creating a draft PR
If you do want to trigger the tests while still in draft then please add a comment with the trigger.
-->

/run cluster-test-suites
