### PR TITLE
disable renovate app updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Disable Renovate app updates.
+
 ## [0.16.0] - 2024-08-23
 
 > [!WARNING]

--- a/helm/default-apps-vsphere/values.yaml
+++ b/helm/default-apps-vsphere/values.yaml
@@ -75,8 +75,6 @@ apps:
       secret: false
     forceUpgrade: true
     namespace: kube-system
-    # used by renovate
-    # repo: giantswarm/cert-exporter
     version: 2.9.2
   certManager:
     appName: cert-manager
@@ -88,8 +86,6 @@ apps:
     dependsOn: prometheus-operator-crd
     forceUpgrade: true
     namespace: kube-system
-    # used by renovate
-    # repo: giantswarm/cert-manager-app
     version: 3.8.1
   chartOperatorExtensions:
     appName: chart-operator-extensions
@@ -100,8 +96,6 @@ apps:
       secret: false
     dependsOn: prometheus-operator-crd
     namespace: giantswarm
-    # used by renovate
-    # repo: giantswarm/chart-operator-extensions
     version: 1.1.2
   ciliumServiceMonitors:
     appName: cilium-servicemonitors
@@ -112,8 +106,6 @@ apps:
       secret: false
     dependsOn: prometheus-operator-crd
     namespace: kube-system
-    # used by renovate
-    # repo: giantswarm/cilium-servicemonitors-app
     version: 0.1.2
   etcdKubernetesResourceCountExporter:
     appName: etcd-k8s-res-count-exporter
@@ -124,16 +116,12 @@ apps:
       secret: false
     forceUpgrade: false
     namespace: kube-system
-    # used by renovate
-    # repo: giantswarm/etcd-kubernetes-resources-count-exporter
     version: 1.10.0
   k8sDnsNodeCache:
     appName: k8s-dns-node-cache
     chartName: k8s-dns-node-cache-app
     catalog: default
     namespace: kube-system
-    # used by renovate
-    # repo: giantswarm/k8s-dns-node-cache-app
     version: 2.8.1
   metricsServer:
     appName: metrics-server
@@ -144,8 +132,6 @@ apps:
       secret: false
     forceUpgrade: true
     namespace: kube-system
-    # used by renovate
-    # repo: giantswarm/metrics-server-app
     version: 2.4.2
   netExporter:
     appName: net-exporter
@@ -156,8 +142,6 @@ apps:
       secret: false
     forceUpgrade: true
     namespace: kube-system
-    # used by renovate
-    # repo: giantswarm/net-exporter
     version: 1.21.0
   nodeExporter:
     appName: node-exporter
@@ -168,8 +152,6 @@ apps:
       secret: false
     forceUpgrade: true
     namespace: kube-system
-    # used by renovate
-    # repo: giantswarm/node-exporter-app
     version: 1.19.0
   observabilityBundle:
     appName: observability-bundle
@@ -181,8 +163,6 @@ apps:
     forceUpgrade: false
     inCluster: true
     namespace: kube-system
-    # used by renovate
-    # repo: giantswarm/observability-bundle
     version: 1.5.3
   observabilityPolicies:
     appName: observability-policies
@@ -193,8 +173,6 @@ apps:
       secret: false
     dependsOn: kyverno-crds
     namespace: kube-system
-    # used by renovate
-    # repo: giantswarm/observability-policies-app
     version: 0.0.1
   securityBundle:
     appName: security-bundle
@@ -206,8 +184,6 @@ apps:
     forceUpgrade: false
     inCluster: true
     namespace: kube-system
-    # used by renovate
-    # repo: giantswarm/security-bundle
     version: 1.8.1
   vpa:
     appName: vertical-pod-autoscaler
@@ -219,8 +195,6 @@ apps:
     dependsOn: vertical-pod-autoscaler-crd
     forceUpgrade: false
     namespace: kube-system
-    # used by renovate
-    # repo: giantswarm/vertical-pod-autoscaler-app
     version: 5.2.4
   vpaCRD:
     appName: vertical-pod-autoscaler-crd
@@ -231,8 +205,6 @@ apps:
       secret: false
     forceUpgrade: false
     namespace: kube-system
-    # used by renovate
-    # repo: giantswarm/vertical-pod-autoscaler-crd
     version: 3.1.0
   teleport-kube-agent:
     appName: teleport-kube-agent
@@ -243,8 +215,6 @@ apps:
       secret: true
     forceUpgrade: true
     namespace: kube-system
-    # used by renovate
-    # repo: giantswarm/teleport-kube-agent-app
     version: 0.9.2
     # a list of extraConfigs for the App,
     # It can be secret or configmap


### PR DESCRIPTION
There's no point updating apps in this repo anymore as it is no longer used after release v0.16.0. Let's disable the updates to save on noise until such time as the repo is archived.

